### PR TITLE
Bug Fix: find returns wrong value for files with same names but different paths

### DIFF
--- a/src/mega/mega.py
+++ b/src/mega/mega.py
@@ -342,7 +342,7 @@ class Mega:
                     ):
                         continue
                     return file
-            if (filename and file[1]['a'] and file[1]['a']['n'] == filename):
+            elif (filename and file[1]['a'] and file[1]['a']['n'] == filename):
                 if (
                     exclude_deleted
                     and self._trash_folder_node_id == file[1]['p']


### PR DESCRIPTION
Current issue:

For this file system configuration:
+-- my_first_dir
|   +-- my_file.txt
+-- my_second_dir
|   +-- an_other_file.txt

find will returns true if you search for the path "my_second_dir/my_file.txt"