### PR TITLE
#TypeError: string indices must be integers

### DIFF
--- a/src/mega/mega.py
+++ b/src/mega/mega.py
@@ -302,8 +302,7 @@ class Mega:
         for foldername in paths:
             if foldername != '':
                 for file in files.items():
-                    if (file[1]['a'] and file[1]['t']
-                            and file[1]['a']['n'] == foldername):
+                    if (isinstance (file[1]['a'], dict) and file[1]['t'] and file[1]['a']['n'] == foldername): 
                         if parent_desc == file[1]['p']:
                             parent_desc = file[0]
                             found = True


### PR DESCRIPTION
I propose to replace this will remove the error creating the file when compiling

#if (file[1]['a'] and file[1]['t'] and file[1]['a']['n'] == foldername):
by
#if (isinstance (file[1]['a'], dict) and file[1]['t'] and file[1]['a']['n'] == foldername):